### PR TITLE
Replaced IHealthCheck with new type IWatchdogCheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Adds support for Systemd Watchdog to [Microsoft.Extensions.Hosting.Systemd](http
 
 Add the packages [Extensions.Hosting.Systemd.Watchdog](https://www.nuget.org/packages/Extensions.Hosting.Systemd.Watchdog) which is hosted on NuGet.
 
-### Enabling watchdog:
+### Enabling watchdog
 
 Invoke the `UseSystemd` overload that takes a bool.
 
@@ -17,7 +17,7 @@ var host = new HostBuilder()
     .UseSystemd(enableWatchdog: true)
     .ConfigureServices((hostContext, services) =>
     {
-        services.AddSingleton<IHealthCheck>(new SignalHealthCheck(TimeSpan.FromMinutes(5)));
+        services.AddSingleton<IWatchdogCheck>(new SignalHealthCheck(TimeSpan.FromMinutes(5)));
     })
 ```
 
@@ -26,12 +26,12 @@ or when using the .net 8 `HostApplicationBuilder`:
 ```c#
 var builder = Host.CreateApplicationBuilder(args);
 builder.UseSystemd(enableWatchdog: true);
-builder.Services.AddSingleton<IHealthCheck>(new SignalHealthCheck(TimeSpan.FromMinutes(5));
+builder.Services.AddSingleton<IWatchdogCheck>(new SignalHealthCheck(TimeSpan.FromMinutes(5));
 ```
 
 ### Register health checks
 
-The watchdog needs an implementation for `IHeathCheck` and the results of its `IsHealhty` property is used to notify the state to systemd. Register at least 1 `IHealthCheck` implementation. The watchdog routing will probe all registered implementations.
+The watchdog needs an implementation for `IWatchdogCheck` and the results of its `IsHealhty` property is used to notify the state to systemd. Register at least 1 `IWatchdogCheck` implementation. The watchdog routing will probe all registered implementations.
 
 ```c#
 var host = new HostBuilder()
@@ -43,6 +43,10 @@ var host = new HostBuilder()
 ```
 
 Not registering at least one health check will result in a startup failure.
+
+## IWatchdogCheck.IsHealthy
+
+The `IWatchdogCheck` interface `IsHealthy` should return immediately based on in-memory state. It should not execute the actual healthcheck. Execute the actual healthcheck in a background task or set the `IsHealthy` value based on the outcome of a operation in the system.
 
 ### Example health check
 

--- a/src/Demo/ActivityMonitor.cs
+++ b/src/Demo/ActivityMonitor.cs
@@ -2,13 +2,13 @@
 using Microsoft.Extensions.Options;
 using System.Threading;
 
-class ActivityMonitor : IHealthCheck
+class ActivityMonitor : IWatchdogCheck
 {
     readonly CancellationTokenSource Cts;
     readonly CancellationToken Ct;
     readonly ILogger Log;
 
-    bool IHealthCheck.IsHealthy
+    bool IWatchdogCheck.IsHealthy
     {
         get
         {

--- a/src/Demo/Program.cs
+++ b/src/Demo/Program.cs
@@ -9,7 +9,7 @@ var builder = Host.CreateApplicationBuilder(args);
 builder.UseSystemd();
 builder.Services
     .AddHostedService<Worker>()
-    .AddSingleton<IHealthCheck, ActivityMonitor>();
+    .AddSingleton<IWatchdogCheck, ActivityMonitor>();
 
 #else
 var builder = Host.CreateDefaultBuilder(args)
@@ -17,7 +17,7 @@ var builder = Host.CreateDefaultBuilder(args)
     .ConfigureServices((context, services) =>
     {
         services.AddHostedService<Worker>();
-        services.AddSingleton<IHealthCheck, ActivityMonitor>();
+        services.AddSingleton<IWatchdogCheck, ActivityMonitor>();
     });
 #endif
 

--- a/src/Watchdog/IHealthCheck.cs
+++ b/src/Watchdog/IHealthCheck.cs
@@ -1,4 +1,7 @@
-﻿public interface IHealthCheck
+﻿using System;
+
+[Obsolete("Use IWatchdogCheck", true)]
+public interface IHealthCheck
 {
     bool IsHealthy { get; }
 }

--- a/src/Watchdog/IWatchdogCheck.cs
+++ b/src/Watchdog/IWatchdogCheck.cs
@@ -1,0 +1,4 @@
+public interface IWatchdogCheck
+{
+    bool IsHealthy { get; }
+}


### PR DESCRIPTION
Replaced IHealthCheck with new type IWatchdogCheck to remove confusion with Health checks in ASP.NET Core.

Resolves:

- #2 